### PR TITLE
Use this, global and window cause exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
     global.inspectf = f();
   }
 
-}(/*istanbul ignore next*/(global || window || this), function() {
+}(/*istanbul ignore next*/this, function() {
 
   'use strict';
 


### PR DESCRIPTION
When the global keyword is used in the browser an exception is thrown.
When the window keyword is used in node an exception is thrown.
This should be a reference to the correct global in each environment.
Tested Chrome 61.0.3163.100, Node v8.6.0